### PR TITLE
Fix data queuing on APIProxyHandler while handling DELETE request

### DIFF
--- a/naumanni/web/proxy.py
+++ b/naumanni/web/proxy.py
@@ -62,6 +62,8 @@ class APIProxyHandler(tornado.web.RequestHandler, NaumanniRequestHandlerMixIn):
         return self.run(*args, **kwargs)
 
     def data_received(self, chunk):
+        if self.content_length is None:
+            return
         self.data_queue.put(chunk)
 
         self.total_bytes += len(chunk)


### PR DESCRIPTION
If the request is DELETE, it occurs TypeError at comparing with `total_bytes`