### PR TITLE
Handle proxy error

### DIFF
--- a/naumanni/web/proxy.py
+++ b/naumanni/web/proxy.py
@@ -89,15 +89,15 @@ class APIProxyHandler(tornado.web.RequestHandler, NaumanniRequestHandlerMixIn):
             response = await self._pass_request(request_url)
         except httpclient.HTTPError as e:
             logger.error(traceback.format_exc())
-            if e.code // 100 == 5:
-                self.set_status(400)  # FIXME: appropriate status code?
+            if 500 <= e.code <= 599:
+                self.set_status(422)
                 self.finish({'reason': 'Server Error occured while proxying'})
             else:
                 self.set_status(e.code)
                 self.finish({'reason': 'Request failed while proxying'})
         except ssl.SSLError:
             logger.error(traceback.format_exc())
-            self.set_status(400)  # FIXME: appropriate status code?
+            self.set_status(422)
             self.finish({'reason': 'SSL handshake failure occured while proxying'})
         else:
             if response.code == 200:

--- a/naumanni/web/proxy.py
+++ b/naumanni/web/proxy.py
@@ -2,6 +2,8 @@
 import logging
 import json
 import re
+import ssl
+import traceback
 from urllib.parse import quote, urlsplit, urlunsplit
 
 from tornado import gen, httpclient, queues, web
@@ -83,21 +85,35 @@ class APIProxyHandler(tornado.web.RequestHandler, NaumanniRequestHandlerMixIn):
         # TODO: ホスト名チェック
 
         # pass request to mastodon
-        response = await self._pass_request(request_url)
-        if response.code == 200:
-            response_body = await self._filter_response(request_url, response)
-            response_headers = _filter_dict(response.headers, PASS_RESPONSE_HEADERS)
-            response_headers['Cache-Control'] = 'max-age=0, private, must-revalidate'
+        try:
+            response = await self._pass_request(request_url)
+        except httpclient.HTTPError as e:
+            logger.error(traceback.format_exc())
+            if e.code // 100 == 5:
+                self.set_status(400)  # FIXME: appropriate status code?
+                self.finish({'reason': 'Server Error occured while proxying'})
+            else:
+                self.set_status(e.code)
+                self.finish({'reason': 'Request failed while proxying'})
+        except ssl.SSLError:
+            logger.error(traceback.format_exc())
+            self.set_status(400)  # FIXME: appropriate status code?
+            self.finish({'reason': 'SSL handshake failure occured while proxying'})
         else:
-            response_body, response_headers = response.body, response.headers
+            if response.code == 200:
+                response_body = await self._filter_response(request_url, response)
+                response_headers = _filter_dict(response.headers, PASS_RESPONSE_HEADERS)
+                response_headers['Cache-Control'] = 'max-age=0, private, must-revalidate'
+            else:
+                response_body, response_headers = response.body, response.headers
 
-        # response
-        self.set_status(response.code)
-        for k, v in response_headers.items():
-            self.set_header(k, v)
-        self.write(response_body)
-        await self.flush()
-        self.finish()
+            # response
+            self.set_status(response.code)
+            for k, v in response_headers.items():
+                self.set_header(k, v)
+            self.write(response_body)
+            await self.flush()
+            self.finish()
 
     def is_need_authorization(self):
         # appsは認証がなくても作れてしまう

--- a/tests/test_web_proxy.py
+++ b/tests/test_web_proxy.py
@@ -1,7 +1,14 @@
 # -*- coding:utf-8 -*-
+import ssl
+
+import tornado.httpclient
+import tornado.web
+from tornado.testing import AsyncHTTPTestCase
+
 from naumanni.web.proxy import (
     https_prefix_rex, mastodon_api_rex,
 )
+from naumanni.web.proxy import APIProxyHandler
 
 
 def test_rex():
@@ -21,5 +28,62 @@ def test_rex():
     mo = mastodon_api_rex.match('https://friends.nico/api/v1/accounts/verify_credentials?hogehoge')
     assert mo.groups() == ('friends.nico', '/accounts/verify_credentials')
 
-def test_nothing():
-    pass
+
+class MockAPIProxyHandler(APIProxyHandler):
+    def is_need_authorization(self):
+        return False
+
+
+class TestProxyHandlerCaseBase(AsyncHTTPTestCase):
+    def setUp(self):
+        self.path = '/proxy/https://friends.nico/api/v1/accounts/verify_credentials'
+        super().setUp()
+
+    def get_app(self):
+        class _TestApplication(tornado.web.Application):
+            def __init__(self, handler):
+                handlers = [
+                    (r'/proxy/(?P<request_url>.+)', handler),
+                ]
+                super().__init__(handlers)
+        handler = self._get_mock_handler()
+        return _TestApplication(handler)
+
+    def _get_mock_handler(self):
+        raise NotImplementedError
+
+
+class ServerErrorProxyTestCase1(TestProxyHandlerCaseBase):
+    def test_error(self):
+        response = self.fetch(self.path)
+        assert response.code == 400
+
+    def _get_mock_handler(self):
+        class _MockAPIProxyHandler(MockAPIProxyHandler):
+            async def _pass_request(self, request_url):
+                raise tornado.httpclient.HTTPError(503)
+        return _MockAPIProxyHandler
+
+
+class ServerErrorProxyTestCase2(TestProxyHandlerCaseBase):
+    def test_error(self):
+        response = self.fetch(self.path)
+        assert response.code == 404
+
+    def _get_mock_handler(self):
+        class _MockAPIProxyHandler(MockAPIProxyHandler):
+            async def _pass_request(self, request_url):
+                raise tornado.httpclient.HTTPError(404)
+        return _MockAPIProxyHandler
+
+
+class SSLErrorProxyTestCase(TestProxyHandlerCaseBase):
+    def test_error(self):
+        response = self.fetch(self.path)
+        assert response.code == 400
+
+    def _get_mock_handler(self):
+        class _MockAPIProxyHandler(MockAPIProxyHandler):
+            async def _pass_request(self, request_url):
+                raise ssl.SSLError()
+        return _MockAPIProxyHandler

--- a/tests/test_web_proxy.py
+++ b/tests/test_web_proxy.py
@@ -56,7 +56,7 @@ class TestProxyHandlerCaseBase(AsyncHTTPTestCase):
 class ServerErrorProxyTestCase1(TestProxyHandlerCaseBase):
     def test_error(self):
         response = self.fetch(self.path)
-        assert response.code == 400
+        assert response.code == 422
 
     def _get_mock_handler(self):
         class _MockAPIProxyHandler(MockAPIProxyHandler):
@@ -80,7 +80,7 @@ class ServerErrorProxyTestCase2(TestProxyHandlerCaseBase):
 class SSLErrorProxyTestCase(TestProxyHandlerCaseBase):
     def test_error(self):
         response = self.fetch(self.path)
-        assert response.code == 400
+        assert response.code == 422
 
     def _get_mock_handler(self):
         class _MockAPIProxyHandler(MockAPIProxyHandler):


### PR DESCRIPTION
## 概要
proxyしたリクエスト結果が5xxエラー or リクエスト中に例外が生じた場合、naumanniサーバ自体がエラーにならないようにハンドリングして適当な4xxレスポンスをクライアントに返却するように